### PR TITLE
Add training script with root path setup

### DIFF
--- a/scripts/treinar_modelo.py
+++ b/scripts/treinar_modelo.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+# Adicionar raiz do projeto ao path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from scripts.func import gerar_base_rh_analitico
+
+
+def main():
+    print("Gerando dados para treinamento...")
+    df = gerar_base_rh_analitico(qtd_amostras=100_000, semente=42)
+    print(df.head())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add missing `scripts/treinar_modelo.py`
- ensure the script adds the project root to `sys.path`
- update import to `from scripts.func import gerar_base_rh_analitico`

## Testing
- `python -m py_compile scripts/gerar_dataset.py scripts/func.py app/main.py`
- `python -m py_compile scripts/treinar_modelo.py`


------
https://chatgpt.com/codex/tasks/task_e_68686e71a21c832cb90b02694c48e4e1